### PR TITLE
Update RfDivSel parameter

### DIFF
--- a/adf4351.c
+++ b/adf4351.c
@@ -165,7 +165,8 @@ ADF4351_ERR_t UpdateFrequencyRegisters(double RFout, double REFin, double Output
 		ADF4351_Reg0.b.IntVal = (INT & 0xffff);
 		ADF4351_Reg1.b.ModVal = (MOD & 0x0fff);
 		ADF4351_Reg4.b.BandClkDiv = BandSelectClockDivider; 
-		
+		ADF4351_Reg4.b.RfDivSel = ADF4351_Select_Output_Divider(RFout);
+	
 		if (*RFoutCalc == RFout) 
 			return ADF4351_Err_None;
 		else


### PR DESCRIPTION
The "OutputDivider" is calculated, but the "RfDivSel" parameter in the "ADF4351_Reg4" register is not updated. This results in an incorrect output frequency when the required frequency is below 2.2 GHz.